### PR TITLE
Upgrades Qewl onSubmit to return apollo promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groundbreaker/qewl",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "React Apollo and AppSync middleware designed to eliminate graqhql boilerplate code.",
   "license": "MIT",
   "author": "GroundBreaker Engineering Team <eng@groundbreaker.co>",

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -101,7 +101,8 @@ const decorateEdit = ({
       },
       props: props => ({
         formData: processFormData(props.data[mutationVars.detailQueryName]),
-        data: props.data[mutationVars.detailQueryName]
+        data: props.data[mutationVars.detailQueryName],
+        loading: props.data.loading
       })
     }),
     graphql(mutation, {

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -44,12 +44,11 @@ const decorateCreate = ({
         ]
       },
       props: props => ({
-        onSubmit: data => {
+        onSubmit: data =>
           props.mutate({
             mutation: mutation,
             variables: { input: data }
-          });
-        }
+          })
       })
     }),
     branch(
@@ -107,9 +106,8 @@ const decorateEdit = ({
     }),
     graphql(mutation, {
       props: props => ({
-        onSubmit: data => {
-          props.mutate({ mutation: mutation, variables: { input: data } });
-        }
+        onSubmit: data =>
+          props.mutate({ mutation: mutation, variables: { input: data } })
       })
     }),
     withProps(props => processSchemas(props.apiSchema, mutationVars)),

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -17,7 +17,8 @@ const decorateDetail = ({ Loading, resource, fields, params, queryName }) => {
         fetchPolicy: "cache-and-network"
       }),
       props: props => ({
-        data: props.data[query]
+        data: props.data[query],
+        loading: props.data.loading
       })
     }),
     branch(
@@ -39,7 +40,8 @@ const decorateList = ({ Loading, resource, fields, params, queryName }) => {
         variables: params
       },
       props: props => ({
-        data: (props.data[query] && props.data[query].items) || []
+        data: (props.data[query] && props.data[query].items) || [],
+        loading: props.data.loading
       })
     }),
     branch(


### PR DESCRIPTION
Previously qewl called apollo-react's mutation function, but returned undefined.  Now it returns the promise from apollo, allowing us to do stuff like await the mutation before kicking the user somewhere else.