### PR TITLE
Fixes optional list handling / enum processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groundbreaker/qewl",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "React Apollo and AppSync middleware designed to eliminate graqhql boilerplate code.",
   "license": "MIT",
   "author": "GroundBreaker Engineering Team <eng@groundbreaker.co>",

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -225,6 +225,14 @@ export const processProperties = (apiSchema, fields) => {
         );
       }
     }
+    if (field.type.kind === "LIST") {
+      const { name, kind, ofType } = field.type;
+      properties[field.name] = {
+        type: "array",
+        title: processTitle(field.name),
+        items: toJSONSchema(pluckFields(apiSchema, ofType.name), apiSchema)
+      };
+    }
   });
 
   return properties;
@@ -247,7 +255,7 @@ export const processEnum = (fieldName, values) => ({
   type: "string",
   title: processTitle(fieldName),
   enum: values,
-  enumNames: values.map(value => titleize(value))
+  enumNames: values.map(value => humanize(value))
 });
 
 export const processRequired = fields => {

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -255,7 +255,7 @@ export const processEnum = (fieldName, values) => ({
   type: "string",
   title: processTitle(fieldName),
   enum: values,
-  enumNames: values.map(value => humanize(value))
+  enumNames: values.map(value => titleize(humanize(value)))
 });
 
 export const processRequired = fields => {


### PR DESCRIPTION
Previously qewl did not handle the case of a optional list input.

Also, for enums like "WORK_FAX", qewl previously
underscore.string.titleized them to "Work_fax".  It seems like the proper
behavior should be to humanize them to  "Work fax" but I could also see the
desire to do both (so, "Work Fax").  Let me know and I should tweak the PR 
to do that.