### PR TITLE
Adds Ability to Disable Refetch

### DIFF
--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -21,15 +21,20 @@ const awsScalars = {
 const decorateCreate = args => {
   const mutationVars = processMutationVars(args);
   const mutation = gqlMutate(mutationVars, args.fields);
+  let refetch = true;
+  if (args.refetch === false) refetch = false;
 
   return compose(
     graphql(mutation, {
       options: {
-        refetchQueries: [
-          {
-            query: gqlFetchList(mutationVars.queryName, args.fields)
-          }
-        ]
+        ...(() =>
+          refetch && {
+            refetchQueries: [
+              {
+                query: gqlFetchList(mutationVars.queryName, args.fields)
+              }
+            ]
+          })()
       },
       props: props => ({
         onSubmit: data =>


### PR DESCRIPTION
Certain graphql `mutations` like `resetPassword` don't currently mutate anything in the graph, so we know there is no need to update the cache or perform a refetch after the mutation happens.  This PR allows invocation of `decorateCreate` with the option `{ refetch: false }` to skip refetching.