### PR TITLE
Update Detail Fetch with Option to Query Without ID

### DIFF
--- a/src/common/index.js
+++ b/src/common/index.js
@@ -8,7 +8,7 @@ export const gqlFetchDetail = (queryName, fields, queryWithoutId) => {
       }
     }`;
   }
-  return gql`query($id: ID!) {
+  return gql`query($id: ID) {
           ${queryName}(
             id: $id
           ) {

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -1,6 +1,13 @@
 import gql from "graphql-tag";
 
-export const gqlFetchDetail = (queryName, fields) => {
+export const gqlFetchDetail = (queryName, fields, queryWithoutId) => {
+  if (queryWithoutId) {
+    return gql`query {
+      ${queryName} {
+        ${fields}
+      }
+    }`;
+  }
   return gql`query($id: ID!) {
           ${queryName}(
             id: $id

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -50,16 +50,16 @@ const decorateCreate = args => {
 };
 
 const decorateEdit = args => {
+  const {
+    fields,
+    params: { queryWithoutId }
+  } = args;
   const mutationVars = processMutationVars({ ...args, ...{ update: true } });
   const mutation = gqlMutate(mutationVars, args.fields);
 
   return compose(
     graphql(
-      gqlFetchDetail(
-        mutationVars.detailQueryName,
-        args.fields,
-        args.params.queryWithoutId
-      ),
+      gqlFetchDetail(mutationVars.detailQueryName, fields, queryWithoutId),
       {
         options: props => {
           return {

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -54,36 +54,45 @@ const decorateEdit = args => {
   const mutation = gqlMutate(mutationVars, args.fields);
 
   return compose(
-    graphql(gqlFetchDetail(mutationVars.detailQueryName, args.fields), {
-      options: props => {
-        return {
-          variables: {
-            id:
-              (props && props.id) ||
-              (args.params && args.params.id) ||
-              props.match.params.id
-          },
-          fetchPolicy: "cache-and-network",
-          refetchQueries: [
-            {
-              query: gqlFetchList(mutationVars.queryName, args.fields)
-            }
-          ]
-        };
-      },
-      props: props => ({
-        formData: processFormData(props.data[mutationVars.detailQueryName]),
-        data: props.data[mutationVars.detailQueryName],
-        loading: props.data.loading,
-        ...(() =>
-          props.data.error ? { apolloInternalError: props.data.error } : {})()
-      })
-    }),
+    graphql(
+      gqlFetchDetail(
+        mutationVars.detailQueryName,
+        args.fields,
+        args.params.queryWithoutId
+      ),
+      {
+        options: props => {
+          return {
+            variables: {
+              id:
+                (props && props.id) ||
+                (args.params && args.params.id) ||
+                props.match.params.id
+            },
+            fetchPolicy: "cache-and-network",
+            refetchQueries: [
+              {
+                query: gqlFetchList(mutationVars.queryName, args.fields)
+              }
+            ]
+          };
+        },
+        props: props => ({
+          formData: processFormData(props.data[mutationVars.detailQueryName]),
+          data: props.data[mutationVars.detailQueryName],
+          loading: props.data.loading,
+          ...(() =>
+            props.data.error ? { apolloInternalError: props.data.error } : {})()
+        })
+      }
+    ),
     graphql(mutation, {
-      props: props => ({
-        onSubmit: data =>
-          props.mutate({ mutation: mutation, variables: { input: data } })
-      })
+      props: props => {
+        return {
+          onSubmit: data =>
+            props.mutate({ mutation: mutation, variables: { input: data } })
+        };
+      }
     }),
     withProps(props => processSchemas(props.apiSchema, mutationVars)),
     branch(

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -50,10 +50,8 @@ const decorateCreate = args => {
 };
 
 const decorateEdit = args => {
-  const {
-    fields,
-    params: { queryWithoutId }
-  } = args;
+  const { fields, params } = args;
+  const queryWithoutId = params && params.queryWithoutId;
   const mutationVars = processMutationVars({ ...args, ...{ update: true } });
   const mutation = gqlMutate(mutationVars, args.fields);
 

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -87,12 +87,10 @@ const decorateEdit = args => {
       }
     ),
     graphql(mutation, {
-      props: props => {
-        return {
-          onSubmit: data =>
-            props.mutate({ mutation: mutation, variables: { input: data } })
-        };
-      }
+      props: props => ({
+        onSubmit: data =>
+          props.mutate({ mutation: mutation, variables: { input: data } })
+      })
     }),
     withProps(props => processSchemas(props.apiSchema, mutationVars)),
     branch(

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -6,10 +6,11 @@ import _ from "underscore";
 import { gqlFetchDetail, gqlFetchList } from "../common";
 
 const decorateDetail = ({ Loading, resource, fields, params, queryName }) => {
+  const { queryWithoutId } = params;
   const query = queryName || `get${resource}`;
 
   return compose(
-    graphql(gqlFetchDetail(query, fields, params.queryWithoutId), {
+    graphql(gqlFetchDetail(query, fields, queryWithoutId), {
       options: props => ({
         variables: {
           ...{ id: (params && params.id) || props.match.params.id }

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -9,7 +9,7 @@ const decorateDetail = ({ Loading, resource, fields, params, queryName }) => {
   const query = queryName || `get${resource}`;
 
   return compose(
-    graphql(gqlFetchDetail(query, fields), {
+    graphql(gqlFetchDetail(query, fields, params.queryWithoutId), {
       options: props => ({
         variables: {
           ...{ id: (params && params.id) || props.match.params.id }

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -6,7 +6,7 @@ import _ from "underscore";
 import { gqlFetchDetail, gqlFetchList } from "../common";
 
 const decorateDetail = ({ Loading, resource, fields, params, queryName }) => {
-  const { queryWithoutId } = params;
+  const queryWithoutId = params && params.queryWithoutId;
   const query = queryName || `get${resource}`;
 
   return compose(


### PR DESCRIPTION
Some of our queries (ie `currentUserProfile`) won't be designed to take any arguments like `id`. This pull solves that by giving the params object an option to run a query without passing in any arguments.