### PR TITLE
Fixes handling of NON - `NON_NULL` array types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groundbreaker/qewl",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "React Apollo and AppSync middleware designed to eliminate graqhql boilerplate code.",
   "license": "MIT",
   "author": "GroundBreaker Engineering Team <eng@groundbreaker.co>",

--- a/src/utils/json-schema.js
+++ b/src/utils/json-schema.js
@@ -67,11 +67,17 @@ export const processProperties = (apiSchema, fields) => {
     }
 
     if (field.type.ofType) {
-      const {
-        type: {
-          ofType: { kind, name, ofType }
-        }
+      let {
+        type: { kind, name, ofType }
       } = field;
+
+      const validTypes = { LIST: 1, INPUT_OBJECT: 1, SCALAR: 1, ENUM: 1 };
+
+      if (!(kind in validTypes)) {
+        kind = ofType.kind;
+        name = ofType.name;
+        ofType = ofType.ofType;
+      }
 
       if (kind === "LIST") {
         properties[field.name] = {


### PR DESCRIPTION
Tests for a type that we can handle, and if so, it handles it.

If not, use the propertes of the ofType definition for sub-field.

As far as I can tell, this gate is more robust that necessary (maybe we can just check for "NON_NULL", but this felt easier because we now test for the graphql types we know we can handle, and assume the rest are metadata types like NON_NULL.).