### PR TITLE
dataKey arg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groundbreaker/qewl",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "React Apollo and AppSync middleware designed to eliminate graqhql boilerplate code.",
   "license": "MIT",
   "author": "GroundBreaker Engineering Team <eng@groundbreaker.co>",

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -59,7 +59,7 @@ const decorateCreateBase = args => {
 };
 
 const decorateEditBase = args => {
-  const { fields, params } = args;
+  const { dataKey, fields, params } = args;
   const queryWithoutId = params && params.queryWithoutId;
   const mutationVars = processMutationVars({ ...args, ...{ update: true } });
   const mutation = gqlMutate(mutationVars, args.fields);
@@ -87,7 +87,7 @@ const decorateEditBase = args => {
         },
         props: props => ({
           formData: processFormData(props.data[mutationVars.detailQueryName]),
-          data: props.data[mutationVars.detailQueryName],
+          [dataKey || `data`]: props.data[mutationVars.detailQueryName],
           loading: props.data.loading,
           apolloInternalError: props.data.error
         })

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -6,7 +6,7 @@ import _ from "underscore";
 import { gqlFetchDetail, gqlFetchList, mapperWrapper } from "../common";
 
 const decorateDetailBase = args => {
-  const { Loading, resource, fields, params, queryName } = args;
+  const { dataKey, fields, Loading, params, queryName, resource } = args;
   const queryWithoutId = params && params.queryWithoutId;
   const query = queryName || `get${resource}`;
 
@@ -22,7 +22,7 @@ const decorateDetailBase = args => {
       }),
       props: props => ({
         ...(() => props.data.error && console.log("APOLLO ERROR", props))(),
-        data: props.data[query],
+        [dataKey || `data`]: props.data[query],
         loading: props.data.loading
       })
     }),
@@ -37,7 +37,7 @@ const decorateDetailBase = args => {
 };
 
 const decorateListBase = args => {
-  const { Loading, resource, fields, params, queryName } = args;
+  const { dataKey, fields, Loading, params, queryName, resource } = args;
   const query = queryName || `list${pluralize(resource)}`;
 
   return compose(
@@ -60,7 +60,8 @@ const decorateListBase = args => {
               })
             });
           },
-          data: (props.data[query] && props.data[query].items) || [],
+          [dataKey || `data`]:
+            (props.data[query] && props.data[query].items) || [],
           loading: props.data.loading
         };
       }


### PR DESCRIPTION
sets up decorateList/Detail/Edit to take a `dataKey` arg, which makes it possible to assign the response from the queries to a key other than `data`. this will allow for using multiple data fetching decorators in same component.