### PR TITLE
adds ability for withSchema to take introspection query result argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groundbreaker/qewl",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "React Apollo and AppSync middleware designed to eliminate graqhql boilerplate code.",
   "license": "MIT",
   "author": "GroundBreaker Engineering Team <eng@groundbreaker.co>",

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -1,13 +1,7 @@
 import React from "react";
 import gql from "graphql-tag";
 import { graphql } from "react-apollo";
-import {
-  compose,
-  branch,
-  renderComponent,
-  withProps,
-  setDisplayName
-} from "recompose";
+import { compose, branch, renderComponent, setDisplayName } from "recompose";
 import _ from "underscore";
 import pluralize from "pluralize";
 import { gqlFetchDetail, gqlFetchList, mapperWrapper } from "../common";

--- a/src/withSchema/index.js
+++ b/src/withSchema/index.js
@@ -1,9 +1,17 @@
 import _ from "underscore";
 import { introspectionQuery, parse } from "graphql";
 import { graphql } from "react-apollo";
-import { compose } from "recompose";
+import { compose, withProps } from "recompose";
 
-const withSchema = () => {
+const withSchema = fullIntrospectionQuery => {
+  if (fullIntrospectionQuery) {
+    return compose(
+      withProps({
+        apiSchema: generateApiSchema(fullIntrospectionQuery.__schema)
+      })
+    );
+  }
+
   return compose(
     graphql(
       parse(introspectionQuery, {


### PR DESCRIPTION
this allows for results of introspectionQuery result to be passed in as an argument to withSchema helping to avoid the costly network request if desired