### PR TITLE
fixes for decorateEdit no render

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groundbreaker/qewl",
-  "version": "1.21.2",
+  "version": "1.21.3",
   "description": "React Apollo and AppSync middleware designed to eliminate graqhql boilerplate code.",
   "license": "MIT",
   "author": "GroundBreaker Engineering Team <eng@groundbreaker.co>",

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -5,7 +5,6 @@ import {
   setDisplayName,
   branch,
   renderNothing,
-  onlyUpdateForKeys,
   shouldUpdate
 } from "recompose";
 import _ from "underscore";

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -134,7 +134,9 @@ const decorateEditBase = args => {
         };
       }
     }),
-    shouldUpdate(({}, nextProps) => !_.isEmpty(nextProps.data)),
+    shouldUpdate(({}, nextProps) =>
+      prefetchData ? !_.isEmpty(nextProps.data) : true
+    ),
     branch(props => prefetchData && !props[propsDataKey], renderNothing),
     setDisplayName(`Qewl(WithForm)`),
     withForm({

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -34,16 +34,23 @@ const decorateDetailBase = ({
       }),
       props: props => {
         const {
-          data: { fetchMore, subscribeToMore }
+          data: {
+            error: apolloInternalError,
+            fetchMore,
+            loading,
+            networkStatus,
+            subscribeToMore
+          }
         } = props;
         return {
-          apolloInternalError: props.data.error,
+          apolloInternalError,
           [dataKey || `data`]: props.data[query],
-          loading: props.data.loading,
+          [dataKey ? `${dataKey}Loading` : `loading`]: loading,
+          networkStatus,
           [dataKey ? `${dataKey}Refetch` : `refetch`]: params => {
             fetchMore({
               variables: params,
-              updateQuery: (previousResult, { fetchMoreResult }) => ({
+              updateQuery: (_, { fetchMoreResult }) => ({
                 [query]: fetchMoreResult[query]
               })
             });


### PR DESCRIPTION
what does this fix?

we were having an issue with pages not rendering on page transition. these pages required a full refresh to fully propagate. 

why this was happening?

in the decorateEdit HOC we were using: `branch(props => prefetchData && !props[propsDataKey], renderNothing)` to stop the renderTree if we were prefetching data and that data hadn't been returned  by the detail query yet. for some reason once the data had finally came back from the api it was not triggering a re-render which left us in `renderNothing`.

how was this fixed?

I added a `shouldUpdate` HOC before the branch HOC from above that forces an update when `prefetchData = true` & `nextProps.data` contains data. I had to leave the branch component there so that the rest of recompose chain doesn't render unless it has data, if you remove it then `withForm` propagates with no api data merged into its `formData` object, which causes a slew of issues.