### PR TITLE
sets up formName submitKey sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groundbreaker/qewl",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "React Apollo and AppSync middleware designed to eliminate graqhql boilerplate code.",
   "license": "MIT",
   "author": "GroundBreaker Engineering Team <eng@groundbreaker.co>",

--- a/src/mutate/index.js
+++ b/src/mutate/index.js
@@ -38,7 +38,8 @@ const onSubmitFactory = ({
 const decorateCreateBase = args => {
   const mutationVars = processMutationVars(args, "create");
   const mutation = gqlMutate(mutationVars, args.fields);
-  const onSubmitName = args.submitKey || `onSubmit`;
+  const onSubmitName =
+    args.submitKey || args.formName ? `${args.formName}OnSubmit` : `onSubmit`;
 
   const { excludeFromInput, formName } = args;
   const formDataKey = formName ? `${formName}FormData` : `formData`;
@@ -80,7 +81,8 @@ const decorateEditBase = args => {
 
   const mutationVars = processMutationVars(args, "update");
   const mutation = gqlMutate(mutationVars, args.fields);
-  const onSubmitName = args.submitKey || `onSubmit`;
+  const onSubmitName =
+    args.submitKey || args.formName ? `${args.formName}OnSubmit` : `onSubmit`;
 
   /**
    *  TODO: Refactor this entire logic chain to minimize API / complexity


### PR DESCRIPTION
i was running into issues where if multiple decorators were being used in a file the submit keys would collide unless the submitKey prop was explicitly set. i setup the create and edit mutations to look at the formName prop if it's present and use that to form the form submission prop. the submitKey prop still takes precedence over formName.